### PR TITLE
feat(eslint-config): disable import/no-cycle

### DIFF
--- a/packages/eslint-config/.eslintrc.js
+++ b/packages/eslint-config/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
     'import/newline-after-import': 'error',
     'import/no-relative-packages': 'error',
     'import/no-useless-path-segments': 'error',
-    'import/no-cycle': ['error', { maxDepth: 10 }],
+    // 'import/no-cycle': ['error', { maxDepth: 10 }], // Replaced by circular dependency checks by Madge (@see https://www.npmjs.com/package/madge)
     '@typescript-eslint/array-type': [
       'error',
       {


### PR DESCRIPTION
# Summary
Disabled `import/no-cycle` rule

- This PR fixes [Starter: Use Madge to check for cyclic dependencies](https://github.com/Trampoline-CX/website-starters/issues/490)

## 📝 Details
See above

## 📦 Packages
eslint-config

## 💣 Breaking Changes
N/A

## 🧪 How did you test it?
